### PR TITLE
Align Treachery Card types and icons with GF9 edition

### DIFF
--- a/src/card/treachery/Defense.stories.ts
+++ b/src/card/treachery/Defense.stories.ts
@@ -66,15 +66,15 @@ export const PortableSnooper = meta.story({
       },
     ],
     text: 'Text goes here',
-    subName: 'Defense - Poison - Special',
+    subName: 'Defense - Poison',
   },
 });
 
 export const Chemistry = meta.story({
   args: {
     head: `/generated/utils/background/defense.jpg`,
-    icon: [`/generated/utils/background/striped-defense.jpg`, 'vector/icon/snooper.svg'],
-    iconOffset: [0, 8],
+    icon: [`/generated/utils/background/striped-defense.jpg`, 'vector/icon/lightning.svg'],
+    iconOffset: [0, 0],
     name: 'Chemistry',
     decals: [
       {
@@ -86,7 +86,7 @@ export const Chemistry = meta.story({
       },
     ],
     text: 'Play as part of your Battle Plan.\n\nCounts as a poison defense, unless played with another defense. In that case, it counts as a poison weapon.\n\nYou may keep this card if you win this battle.',
-    subName: 'Defense - Poison - Special',
+    subName: 'Defense - Weapon - Special',
   },
 });
 

--- a/src/card/treachery/Unique.stories.ts
+++ b/src/card/treachery/Unique.stories.ts
@@ -265,7 +265,7 @@ export const WeatherControl = meta.story({
         scale: 0.9,
       },
     ],
-    text: 'After the first game turn, play during the Storm Phase after seeing how far the storm moves. You control the storm this turn instead. Pick a number from 0 to 10 and move the storm that far.',
+    text: 'After the first game turn, play during the Storm Phase after seeing how far the storm moves.You control the storm this turn instead. Pick a number from 0 to 10 and move the storm that far.',
     subName: 'Special - Storm',
   },
 });

--- a/src/card/treachery/Unique.stories.ts
+++ b/src/card/treachery/Unique.stories.ts
@@ -106,7 +106,7 @@ export const Amal = meta.story({
       },
     ],
     text: 'At the beginning of any phase, cause all players to discard half of the spice behind their shields, rounded up, to the Spice Bank.',
-    subName: 'Special - Instant',
+    subName: 'Special',
   },
 });
 
@@ -126,7 +126,7 @@ export const FamilyAtomics = meta.story({
       },
     ],
     text: 'You may play this after turn 1, when the storm has been calculated, but before it is moved, if you have forces on or adjacent to the Shield Wall (with no storm inbetween).\n\nAll forces on the Shield Wall are killed. Place the Destroyed Shield Wall token on the Shield Wall. The Imperial Basin, Arrakeen and Carthag are no longer protected from the Storm.',
-    subName: 'Special - Storm phase',
+    subName: 'Special - Storm',
   },
 });
 
@@ -166,7 +166,7 @@ export const Harvester = meta.story({
       },
     ],
     text: 'Play just after a spice blow comes up. Doubles the spice blow. Place double the amount of spice in the territory.',
-    subName: 'Special - Spice blow',
+    subName: 'Spice Blow - Special',
   },
 });
 
@@ -186,7 +186,7 @@ export const Karama = meta.story({
       },
     ],
     text: "Play this card to do one of the following:\n• Disable a faction advantage for the rest of the phase. May be played as a faction advantage is being used.,\n• Pay Guild rates (half price) when you or your ally ships forces onto the planet.\n• If your hand is not full and it's your turn to bid, purchase the treachery card now up for bid without paying spice.",
-    subName: 'Special - Instant',
+    subName: 'Special',
   },
 });
 
@@ -206,7 +206,7 @@ export const Thumper = meta.story({
       },
     ],
     text: 'Play at beginning of Spice Blow Phase instead of revealing the next Spice Blow card. Causes a Sandworm to appear.\n\nPlay proceeds as though Shai-Hulud has been revealed.',
-    subName: 'Special - Spice blow',
+    subName: 'Spice Blow - Special',
   },
 });
 
@@ -226,7 +226,7 @@ export const TleilaxuGhola = meta.story({
       },
     ],
     text: 'Play at any time.\n\nYou may immediately revive 1 of your leaders or up to 5 of your forces at no cost. You still get your normal revivals this turn.',
-    subName: 'Special - Instant',
+    subName: 'Special',
   },
 });
 
@@ -246,7 +246,7 @@ export const TruthTrance = meta.story({
       },
     ],
     text: 'Play at any time.\nPublicly ask one other player a yes/no question that must be answered publicly. The game pauses until an answer is given.\nIf a player answers a question about a future action they cannot make fulfilling that action impossible. They may however take actions that lower the chance of that action being fulfilled.',
-    subName: 'Special - Instant',
+    subName: 'Special',
   },
 });
 
@@ -265,8 +265,8 @@ export const WeatherControl = meta.story({
         scale: 0.9,
       },
     ],
-    text: 'After the first game turn, play during the Storm Phase after seeing how far the storm moves.You control the storm this turn instead. Pick a number from 0 to 10 and move the storm that far.',
-    subName: 'Special - Instant',
+    text: 'After the first game turn, play during the Storm Phase after seeing how far the storm moves. You control the storm this turn instead. Pick a number from 0 to 10 and move the storm that far.',
+    subName: 'Special - Storm',
   },
 });
 
@@ -326,7 +326,7 @@ export const JuiceOfSapho = meta.story({
       },
     ],
     text: 'Text goes here',
-    subName: 'Special - Instant',
+    subName: 'Special',
   },
 });
 
@@ -346,7 +346,7 @@ export const JuiceOfSaphoAlt = meta.story({
       },
     ],
     text: 'Choose one:\nPlay this card to be considered the aggressor in a battle, or\nGo first for any phase or action that requires turn order, or\nGo last for any phase or action that requires turn order (even superseding Guild).\nPlay the card in the applicable phase when you wish to intervene. Discard after use.',
-    subName: 'Special - Instant',
+    subName: 'Special',
   },
 });
 
@@ -366,7 +366,7 @@ export const ResidualPoison = meta.story({
       },
     ],
     text: 'Play on your opponent before choosing leaders in a battle. That faction will lose one of their available leaders at random to the tanks. No spice is collected for it.\nDiscard after use.',
-    subName: 'Special - Instant',
+    subName: 'Special',
   },
 });
 
@@ -386,7 +386,7 @@ export const Ornithopter = meta.story({
       },
     ],
     text: 'As part of your movement, you may move one group of your forces up to 3 territories, or move 2 different groups of your forces up to your normal movement. Discard after use.',
-    subName: 'Special - Instant',
+    subName: 'Special - Movement',
   },
 });
 
@@ -426,7 +426,7 @@ export const SemutaDrug = meta.story({
       },
     ],
     text: 'Take a Treachery Card immediately after another player discards it, and add it to your hand.\nIf multiple cards are discarded at the same time, you choose which card to take. Discard after use.',
-    subName: 'Special - Instant',
+    subName: 'Special',
   },
 });
 
@@ -446,7 +446,7 @@ export const NullentropyBox = meta.story({
       },
     ],
     text: 'At any time, pay 2 spice to the Spice Bank, then take the Treachery Card discard pile and secretly search it for any card (other than a Nullentropy Box) to add to your hand. Shuffle the discard pile afterward and then return it face up, discarding this card on top.',
-    subName: 'Special - Instant',
+    subName: 'Special',
   },
 });
 
@@ -466,6 +466,6 @@ export const Distrance = meta.story({
       },
     ],
     text: "Give another player a Treachery Card from your hand (if that player's hand is not full). Play at any time (other than during a bid). Discard after use.",
-    subName: 'Special - Instant',
+    subName: 'Special',
   },
 });

--- a/src/card/treachery/Weapon.stories.ts
+++ b/src/card/treachery/Weapon.stories.ts
@@ -39,7 +39,7 @@ export const Lasgun = meta.story({
 export const WeirdingWay = meta.story({
   args: {
     head: `/generated/utils/background/weapon.jpg`,
-    icon: [`/generated/utils/background/striped-weapon.jpg`, 'vector/icon/projectile.svg'],
+    icon: [`/generated/utils/background/striped-weapon.jpg`, 'vector/icon/lightning.svg'],
     name: 'Weirding Way',
     decals: [
       {
@@ -51,7 +51,7 @@ export const WeirdingWay = meta.story({
       },
     ],
     text: 'Play as part of your Battle Plan.\nCounts as a projectile weapon, unless played with another weapon. In that case, it counts as a projectile defense.\nYou may keep this card if you win this battle.',
-    subName: 'Weapon - Special',
+    subName: 'Weapon - Defense - Special',
   },
 });
 
@@ -165,7 +165,7 @@ export const PoisonTooth = meta.story({
       },
     ],
     text: 'Play as part of your Battle Plan.\nKills both leaders, and is not stopped by a Snooper.\nAfter seeing the battle results, you may choose not to use this weapon.',
-    subName: 'Weapon - Poison',
+    subName: 'Weapon - Poison - Special',
   },
 });
 

--- a/src/card/treachery/Worthless.stories.ts
+++ b/src/card/treachery/Worthless.stories.ts
@@ -26,7 +26,7 @@ export const Baliset = meta.story({
       },
     ],
     text: 'Play as part of your Battle Plan, in place of a weapon, defense, or both.\nThis card has no value in play, and you can discard it only by playing it in your Battle Plan.',
-    subName: 'Worthless',
+    subName: 'Worthless Card',
   },
 });
 
@@ -46,7 +46,7 @@ export const JubbaCloak = meta.story({
       },
     ],
     text: 'Play as part of your Battle Plan, in place of a weapon, defense, or both.\nThis card has no value in play, and you can discard it only by playing it in your Battle Plan.',
-    subName: 'Worthless',
+    subName: 'Worthless Card',
   },
 });
 
@@ -66,7 +66,7 @@ export const KullWahad = meta.story({
       },
     ],
     text: 'Play as part of your Battle Plan, in place of a weapon, defense, or both.\nThis card has no value in play, and you can discard it only by playing it in your Battle Plan.',
-    subName: 'Worthless',
+    subName: 'Worthless Card',
   },
 });
 
@@ -86,7 +86,7 @@ export const Kulon = meta.story({
       },
     ],
     text: 'Play as part of your Battle Plan, in place of a weapon, defense, or both.\nThis card has no value in play, and you can discard it only by playing it in your Battle Plan.',
-    subName: 'Worthless',
+    subName: 'Worthless Card',
   },
 });
 
@@ -106,7 +106,7 @@ export const LaLaLa = meta.story({
       },
     ],
     text: 'Play as part of your Battle Plan, in place of a weapon, defense, or both.\nThis card has no value in play, and you can discard it only by playing it in your Battle Plan.',
-    subName: 'Worthless',
+    subName: 'Worthless Card',
   },
 });
 
@@ -126,7 +126,7 @@ export const TripToGamond = meta.story({
       },
     ],
     text: 'Play as part of your Battle Plan, in place of a weapon, defense, or both.\nThis card has no value in play, and you can discard it only by playing it in your Battle Plan.',
-    subName: 'Worthless',
+    subName: 'Worthless Card',
   },
 });
 


### PR DESCRIPTION
Update Treachery Card story definitions to better match the GF9 edition by correcting card type labels and icons:

- adjust selected treachery card `subName` values to match physical GF9 card types
- update selected card icons

Only the cards present in GF9 base and expansions were touched.